### PR TITLE
Denoise the output of push

### DIFF
--- a/src/main/bash/push
+++ b/src/main/bash/push
@@ -136,7 +136,7 @@ cd "${workdir}"
 
 for commit in "${to_push[@]}"; do
     status "Preparing to validate and push $commit"
-    git checkout --force "${commit}"
+    git checkout --quiet --force "${commit}"
     git clean -fxd
 
     link_exclusions=()


### PR DESCRIPTION
push checks out a detached head by design, therefore the warning
should be suppressed.